### PR TITLE
Add Specfile and build infrastructure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+CREDITS
+LICENSE
+LICENSE_3RD_PARTY
+README
+airtime_mvc
+changelog
+dev_tools
+docs
+install
+installer
+python_apps
+tests
+uninstall
+utils
+widgets
+RPMS/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.dockerignore
 *.pyc
 *.*~
 vendor/*
@@ -10,3 +11,4 @@ composer.phar
 /airtime_mvc/tests/test_results.xml
 /tests/results.html
 /tests/*.jar
+RPMS/

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN yum install -y \
     python-amqplib \
     python-argcomplete \
     python-six \
-    python-docopt
+    python-docopt \
+    python-configobj
 
 WORKDIR /usr/local/src/airtime
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# This dockerfile contains a runtime for building airtime rpms for centos7
+
+# The resulting image may be used a a one-off build command and creates an rpm
+# of airtime prepared in a fashion so it may be installed in a distributed
+# fashion on centos using rh-scl http24 and php56-fpm as a backend.
+
+FROM centos:7
+
+RUN yum install -y rpm-build rpmdevtools createrepo
+
+WORKDIR /usr/local/src/airtime
+
+COPY Specfile /usr/local/src/airtime/Specfile
+COPY build-rpm.sh /usr/local/src/airtime/build-rpm.sh
+
+CMD ["bash", "/usr/local/src/airtime/build-rpm.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,26 @@
 # fashion on centos using rh-scl http24 and php56-fpm as a backend.
 
 FROM centos:7
-
-RUN yum install -y rpm-build rpmdevtools createrepo
+RUN yum install -y epel-release
+RUN yum install -y \
+    rpm-build \
+    rpmdevtools \
+    createrepo \
+    python-setuptools \
+    python-pip \
+    pytz \
+    python-mutagen \
+    python-kombu \
+    python-anyjson \
+    python-amqp \
+    python-amqplib \
+    python-argcomplete \
+    python-six \
+    python-docopt
 
 WORKDIR /usr/local/src/airtime
 
-COPY Specfile /usr/local/src/airtime/Specfile
-COPY build-rpm.sh /usr/local/src/airtime/build-rpm.sh
+COPY Specfile /root/rpmbuild/SPECS/airtime.spec
+COPY build-rpm.sh /usr/local/bin/build-rpm.sh
 
-CMD ["bash", "/usr/local/src/airtime/build-rpm.sh"]
+CMD ["bash", "/usr/local/bin/build-rpm.sh"]

--- a/Specfile
+++ b/Specfile
@@ -1,6 +1,6 @@
 Name:           airtime
 Version:        2.5.x
-Release:        3%{?dist}.rabe
+Release:        4%{?dist}.rabe
 Summary:        radio rabe airtime installation
 
 License:        AGPL

--- a/Specfile
+++ b/Specfile
@@ -1,6 +1,6 @@
 Name:           airtime
 Version:        2.5.x
-Release:        4%{?dist}.rabe
+Release:        5%{?dist}.rabe
 Summary:        radio rabe airtime installation
 
 License:        AGPL
@@ -49,6 +49,14 @@ cp airtime-test-soundcard \
    $RPM_BUILD_ROOT/usr/bin/
 popd
 
+# install media-monitor python app
+pushd python_apps/media-monitor/
+# this is not called in a specfile :)
+# python setup.py bdist_rpm
+# lets do it using pip :)
+pip install --install-option="--prefix=$RPM_BUILD_ROOT/%{_prefix}"  .
+popd
+
 %clean
 rm -rf $RPM_BUILD_ROOT
 
@@ -64,7 +72,8 @@ rm -rf $RPM_BUILD_ROOT
 
 Summary:    radio rabe airtime web interface installation
 Requires:   rh-php56-php
-#            httpd24-httpd
+Requires:   httpd24-httpd
+Requires:   liquidsoap
 
 %description -n airtime-web
 Installs the airtime web interface into http24/php56 using fpm.
@@ -86,3 +95,39 @@ Installs the various utils neeeded by airtime to d stuff on the cli.
 /usr/sbin/airtime-silan
 /usr/sbin/airtime-import
 /usr/bin/airtime-test-*
+
+%package -n airtime-media-monitor
+
+Summary:   radio rabe airtime media montitor installation
+%description -n airtime-media-monitor
+airtime media-monitor imports uploaded files and watches directories
+
+Requires: pytz
+Requires: python-mutagen
+Require:  python-amqp
+Require:  python-amqplib
+Require:  python-six
+%files -n airtime-media-monitor
+/usr/bin/airtime-media-monitor
+/usr/lib/python2.7/site-packages/_version.py
+/usr/lib/python2.7/site-packages/_version.pyc
+/usr/lib/python2.7/site-packages/_version.pyo
+/usr/lib/python2.7/site-packages/PyDispatcher-2.0.5-py2.7.egg-info/
+/usr/lib/python2.7/site-packages/airtime_media_monitor-1.0-py2.7.egg-info/
+/usr/lib/python2.7/site-packages/amqp-1.0.13-py2.7.egg-info/
+/usr/lib/python2.7/site-packages/amqp/
+/usr/lib/python2.7/site-packages/argparse-1.4.0-py2.7.egg-info/
+/usr/lib/python2.7/site-packages/argparse.*
+/usr/lib/python2.7/site-packages/configobj-5.0.6-py2.7.egg-info/
+/usr/lib/python2.7/site-packages/configobj.*
+/usr/lib/python2.7/site-packages/media_monitor/
+/usr/lib/python2.7/site-packages/mm2/
+/usr/lib/python2.7/site-packages/poster-0.8.1-py2.7.egg-info/
+/usr/lib/python2.7/site-packages/poster/
+/usr/lib/python2.7/site-packages/pydispatch/
+/usr/lib/python2.7/site-packages/pyinotify-0.9.6-py2.7.egg-info/
+/usr/lib/python2.7/site-packages/pyinotify.*
+/usr/lib/python2.7/site-packages/tests/
+/usr/lib/python2.7/site-packages/validate.*
+
+

--- a/Specfile
+++ b/Specfile
@@ -1,6 +1,6 @@
 Name:           airtime
 Version:        2.5.x
-Release:        5%{?dist}.rabe
+Release:        6%{?dist}.rabe
 Summary:        radio rabe airtime installation
 
 License:        AGPL
@@ -107,19 +107,15 @@ Requires: python-mutagen
 Require:  python-amqp
 Require:  python-amqplib
 Require:  python-six
+Require:  python-configobj
 %files -n airtime-media-monitor
 /usr/bin/airtime-media-monitor
-/usr/lib/python2.7/site-packages/_version.py
-/usr/lib/python2.7/site-packages/_version.pyc
-/usr/lib/python2.7/site-packages/_version.pyo
 /usr/lib/python2.7/site-packages/PyDispatcher-2.0.5-py2.7.egg-info/
 /usr/lib/python2.7/site-packages/airtime_media_monitor-1.0-py2.7.egg-info/
 /usr/lib/python2.7/site-packages/amqp-1.0.13-py2.7.egg-info/
 /usr/lib/python2.7/site-packages/amqp/
 /usr/lib/python2.7/site-packages/argparse-1.4.0-py2.7.egg-info/
 /usr/lib/python2.7/site-packages/argparse.*
-/usr/lib/python2.7/site-packages/configobj-5.0.6-py2.7.egg-info/
-/usr/lib/python2.7/site-packages/configobj.*
 /usr/lib/python2.7/site-packages/media_monitor/
 /usr/lib/python2.7/site-packages/mm2/
 /usr/lib/python2.7/site-packages/poster-0.8.1-py2.7.egg-info/
@@ -128,6 +124,5 @@ Require:  python-six
 /usr/lib/python2.7/site-packages/pyinotify-0.9.6-py2.7.egg-info/
 /usr/lib/python2.7/site-packages/pyinotify.*
 /usr/lib/python2.7/site-packages/tests/
-/usr/lib/python2.7/site-packages/validate.*
 
 

--- a/Specfile
+++ b/Specfile
@@ -1,6 +1,6 @@
 Name:           airtime
 Version:        2.5.x
-Release:        1%{?dist}.rabe
+Release:        2%{?dist}.rabe
 Summary:        radio rabe airtime installation
 
 License:        AGPL
@@ -24,11 +24,30 @@ ls -al
 
 %install
 rm -rf $RPM_BUILD_ROOT
+
+# install airtime-web parts so apache finds them
 mkdir -p $RPM_BUILD_ROOT/opt/rh/httpd24/root/var/www/
 cp -rp airtime_mvc/* $RPM_BUILD_ROOT/opt/rh/httpd24/root/var/www/
 ls $RPM_BUILD_ROOT/opt/rh/httpd24/root/var/www
 mv $RPM_BUILD_ROOT/opt/rh/httpd24/root/var/www/public $RPM_BUILD_ROOT/opt/rh/httpd24/root/var/www/html
 
+# install airtime-utils so they can be called by a user
+
+mkdir -p $RPM_BUILD_ROOT/usr/{sbin,bin}
+pushd utils
+cp airtime-backup.py \
+   airtime-log \
+   airtime-log.php \
+   airtime-silan \
+   airtime-import/airtime-import \
+   $RPM_BUILD_ROOT/usr/sbin/
+
+cp airtime-test-soundcard \
+   airtime-test-soundcard.py \
+   airtime-test-stream \
+   airtime-test-stream.py \
+   $RPM_BUILD_ROOT/usr/bin/
+popd
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -37,7 +56,6 @@ rm -rf $RPM_BUILD_ROOT
 %files
 %defattr(-,root,root,-)
 %doc
-
 
 
 %changelog
@@ -53,3 +71,17 @@ Installs the airtime web interface into http24/php56 using fpm.
 
 %files -n airtime-web
 /opt/rh/httpd24/root/var/www/
+
+%package -n airtime-utils
+
+Summary:    radio rabe airtime utils installation
+%description -n airtime-utils
+Installs the various utils neeeded by airtime to d stuff on the cli.
+
+%files -n airtime-utils
+/usr/sbin/airtime-backup.py
+/usr/sbin/airtime-log
+/usr/sbin/airtime-log.php
+/usr/sbin/airtime-silan
+/usr/sbin/airtime-import
+/usr/bin/airtime-test-*

--- a/Specfile
+++ b/Specfile
@@ -1,0 +1,55 @@
+Name:           airtime
+Version:        2.5.x
+Release:        1%{?dist}.rabe
+Summary:        radio rabe airtime installation
+
+License:        AGPL
+URL:            https://github.com/radiorabe/airtime
+Source0:        https://github.com/radiorabe/airtime/archive/2.5.x.zip
+
+#BuildRequires:  
+#Requires:       
+
+%description
+RPM packaging for Radio Bern RaBe's CentOS-7 based installation
+installation of Sourcefabric's Airtime Software.
+
+%prep
+%setup -q
+
+
+%build
+ls -al
+
+
+%install
+rm -rf $RPM_BUILD_ROOT
+mkdir -p $RPM_BUILD_ROOT/opt/rh/httpd24/root/var/www/
+cp -rp airtime_mvc/* $RPM_BUILD_ROOT/opt/rh/httpd24/root/var/www/
+ls $RPM_BUILD_ROOT/opt/rh/httpd24/root/var/www
+mv $RPM_BUILD_ROOT/opt/rh/httpd24/root/var/www/public $RPM_BUILD_ROOT/opt/rh/httpd24/root/var/www/html
+
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+
+%files
+%defattr(-,root,root,-)
+%doc
+
+
+
+%changelog
+
+%package -n airtime-web
+
+Summary:    radio rabe airtime web interface installation
+Requires:   rh-php56-php
+#            httpd24-httpd
+
+%description -n airtime-web
+Installs the airtime web interface into http24/php56 using fpm.
+
+%files -n airtime-web
+/opt/rh/httpd24/root/var/www/

--- a/Specfile
+++ b/Specfile
@@ -1,6 +1,6 @@
 Name:           airtime
 Version:        2.5.x
-Release:        2%{?dist}.rabe
+Release:        3%{?dist}.rabe
 Summary:        radio rabe airtime installation
 
 License:        AGPL
@@ -71,6 +71,7 @@ Installs the airtime web interface into http24/php56 using fpm.
 
 %files -n airtime-web
 /opt/rh/httpd24/root/var/www/
+%config /opt/rh/httpd24/root/var/www/application/configs/application.ini
 
 %package -n airtime-utils
 

--- a/airtime_mvc/application/airtime-boot.php
+++ b/airtime_mvc/application/airtime-boot.php
@@ -16,7 +16,12 @@ function exception_error_handler($errno, $errstr, $errfile, $errline) {
     //Check if the statement that threw this error wanted its errors to be
     //suppressed. If so then return without with throwing exception.
     if (0 === error_reporting()) return;
+    /* throwing an exception from this error leads to an error loop
+     * if we leave this out the errors get handled as php would usually
+     * do letting them get logged to apaches error_log.
+     *
     throw new ErrorException($errstr, $errno, 0, $errfile, $errline);
+     */
     return false;
 }
 

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -1,0 +1,5 @@
+mkdir -p /root/rpmbuild/SOURCES/
+spectool -g -R /usr/local/src/airtime/Specfile
+rpmbuild -ba /usr/local/src/airtime/Specfile
+cd /root/rpmbuild/RPMS/x86_64
+createrepo .

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -1,5 +1,5 @@
 mkdir -p /root/rpmbuild/SOURCES/
-spectool -g -R /usr/local/src/airtime/Specfile
-rpmbuild -ba /usr/local/src/airtime/Specfile
+spectool -g -R /root/rpmbuild/SPECS/airtime.spec
+rpmbuild -ba /root/rpmbuild/SPECS/airtime.spec
 cd /root/rpmbuild/RPMS/x86_64
 createrepo .

--- a/docs/RPM.md
+++ b/docs/RPM.md
@@ -1,0 +1,30 @@
+Building a RaBe Airtime RPM
+===========================
+
+This repo contains a docker environment that may be used to build a airtime rpm based on the source
+of the radiorabe/airtime fork.
+
+You can either directly use the Specfile with `spectool` and `rpmbuild` or run the whole shebang
+through docker if you are on an environment that oes not have native rpm support.
+
+Native RPM Building
+-------------------
+
+Run the following to create some RPMs on a RedHat/CentOS distro.
+
+```bash
+spectool -g -R Specfile
+rpmbuild -ba Specfile
+```
+
+Docker RPM Building
+-------------------
+
+Run this agains any docker instance to build a complete yum repo containing the airtime RPMs.
+
+```bash
+docker build -t airtime-rpm . 
+docker run --rm -ti --volume `pwd`/RPMS:/root/rpmbuild/RPMS airtime-rpm
+```
+
+In the above case the yum repo ends up in ./RPMS/x86_64


### PR DESCRIPTION
A very simple Specfile that only takes care of the airtime-web subpackage in the most simple way. I'm also adding some tools to aid in building the rpms and their corresponding yum repo on non rpm platforms using docker.

For now I gave the RPMs a temporary home at http://yum.hairmare.ch/rabe-airtime-x86_64/ but we need to change that in due course.
